### PR TITLE
feat: update status codes and field names to match updated backend API

### DIFF
--- a/src/components/AnalysisItem.vue
+++ b/src/components/AnalysisItem.vue
@@ -49,11 +49,11 @@
         <hr />
         <div class="row">
           <div class="col-sm">
-            {{ analysis.use_for_archive_settings }}
+            {{ archive_status_name[analysis.archive_status] }}
             <br />
             <p>
               <small>
-                <strong>Used for archiving</strong>
+                <strong>Archive status</strong>
               </small>
             </p>
           </div>
@@ -117,12 +117,23 @@ export default {
       },
       analysis_status_name: {
         WS: "Waiting for sequencing",
+        SC: "Sequencing completed",
         WP: "Waiting for processing",
         RE: "Reserved for processing",
         PR: "Processing",
         AC: "Analysis completed",
         DD: "Data delivered",
         FA: "Processing failed",
+        PD: "Partial demultiplexed",
+      },
+      archive_status_name: {
+        AI: "Do not use for archiving",
+        WS: "Waiting for sequence data",
+        PS: "Partial sequenced data",
+        WA: "Waiting for archiving",
+        BA: "Being archived",
+        FA: "Failed archiving",
+        AD: "Archived done",
       },
       priority: {
         "1-N": "Normal",

--- a/src/components/AnalysisSampleTable.vue
+++ b/src/components/AnalysisSampleTable.vue
@@ -22,9 +22,13 @@
                 </a>
               </td>
               <td>
-                <a :href="`/sequencerun/${sample.sample_id.sequence_run}`">
-                  {{ sample.sample_id.sequence_run }}
+                <a
+                  v-if="sample.sample_id.sequence_run"
+                  :href="`/sequencerun/${sample.sample_id.sequence_run.run_id}`"
+                >
+                  {{ sample.sample_id.sequence_run.run_id }}
                 </a>
+                <span v-else>—</span>
               </td>
               <td>{{ sample.settings }}</td>
               <td>

--- a/src/components/AnalysisTable.vue
+++ b/src/components/AnalysisTable.vue
@@ -39,12 +39,14 @@ export default {
       analysis: [],
       analysis_status_name: {
         WS: "Waiting for sequencing",
+        SC: "Sequencing completed",
         WP: "Waiting for processing",
         RE: "Reserved for processing",
         PR: "Processing",
         AC: "Analysis completed",
         DD: "Data delivered",
         FA: "Processing failed",
+        PD: "Partial demultiplexed",
       },
     };
   },
@@ -59,7 +61,6 @@ export default {
     },
   },
   created() {
-    console.log("CREATED");
     this.getAnalysis();
   },
   methods: {

--- a/src/components/SequenceFilesTable.vue
+++ b/src/components/SequenceFilesTable.vue
@@ -36,7 +36,7 @@
               </a>
             </td>
           </tr>
-          <tr v-if="sequence_file.fastqfiles_set == 0">
+          <tr v-if="sequence_file.fastqfiles_set.length === 0">
             <td class="table-warning" colspan="4">No files added!</td>
           </tr>
           <tr v-else>

--- a/src/components/SequenceRunItem.vue
+++ b/src/components/SequenceRunItem.vue
@@ -61,12 +61,12 @@
             <table v-if="analyzes">
               <tr>
                 <th>Analysis</th>
-                <th>Used for archiving</th>
+                <th>Archive status</th>
               </tr>
               <tr v-for="analysis in analyzes" :key="analysis.analysis_name">
                 <td>{{ analysis.analysis_name }}</td>
                 <td class="text-center">
-                  {{ analysis.use_for_archive_settings }}
+                  {{ archive_status_name[analysis.archive_status] }}
                 </td>
               </tr>
             </table>
@@ -101,11 +101,23 @@ export default {
         NA: "Not Assigned",
         PA: "Partial Assigned",
         AS: "Assigned",
+        NE: "No samplesheet expected",
+      },
+      archive_status_name: {
+        AI: "Do not use for archiving",
+        WS: "Waiting for sequence data",
+        PS: "Partial sequenced data",
+        WA: "Waiting for archiving",
+        BA: "Being archived",
+        FA: "Failed archiving",
+        AD: "Archived done",
       },
       archive_status: {
-        NA: "Not Archived",
-        BE: "Being Archived",
-        AC: "Archived",
+        NA: "Not archived",
+        PA: "Partially archived",
+        AD: "Archived done",
+        AI: "Do not archive",
+        FA: "Failed archiving",
       },
     };
   },
@@ -129,7 +141,6 @@ export default {
         .catch((error) => console.log(error));
     },
     async getAnalsysis() {
-      console.log("api/v1/sequencerun/analysis/" + this.sequencerun_id + "/");
       await axios
         .get("api/v1/sequencerun/analysis/" + this.sequencerun_id + "/")
         .then((response) => {

--- a/src/components/SequenceRunTable.vue
+++ b/src/components/SequenceRunTable.vue
@@ -49,7 +49,7 @@ export default {
       },
       archive_status_dict: {
         NA: "Not archived",
-        BA: "Being archived",
+        PA: "Partially archived",
         FA: "Failed archiving",
         AD: "Archived done",
         AI: "Do not archive",

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -23,38 +23,40 @@
               </tr>
               <tr>
                 <th scope="col">Waiting for Sequencing</th>
+                <th scope="col">Sequencing Completed</th>
                 <th scope="col">Unprocessed</th>
                 <th scope="col">Reserved</th>
                 <th scope="col">Processing</th>
                 <th scope="col">Done</th>
-                <th scope="col">Deliverd</th>
+                <th scope="col">Delivered</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>{{ analysis_ws }}</td>
+                <td>{{ analysis_sc }}</td>
                 <td>{{ analysis_wp }}</td>
                 <td>{{ analysis_re }}</td>
                 <td>{{ analysis_pr }}</td>
-                <td>{{ analysis_ad }}</td>
+                <td>{{ analysis_ac }}</td>
                 <td>{{ analysis_dd }}</td>
               </tr>
             </tbody>
           </table>
-          <table v-if="analysis_fa || analysis_pa" class="table">
+          <table v-if="analysis_fa || analysis_pd" class="table">
             <thead>
               <tr>
                 <th scope="col" colspan="6">Processing Failures</th>
               </tr>
               <tr>
                 <th scope="col">Failed</th>
-                <th scope="col" colspan="5">Partial Sequenced</th>
+                <th scope="col" colspan="5">Partial Demultiplexed</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>{{ analysis_fa }}</td>
-                <td>{{ analysis_pa }}</td>
+                <td>{{ analysis_pd }}</td>
               </tr>
             </tbody>
           </table>
@@ -67,7 +69,7 @@
               <tr>
                 <th scope="col">Done</th>
                 <th scope="col">Not Archived</th>
-                <th scope="col">Archiving</th>
+                <th scope="col">Partially Archived</th>
                 <th scope="col">Failed</th>
               </tr>
             </thead>
@@ -75,7 +77,7 @@
               <tr>
                 <td>{{ archived_count }}</td>
                 <td>{{ not_archived_count }}</td>
-                <td>{{ archiving_count }}</td>
+                <td>{{ partially_archived_count }}</td>
                 <td>{{ failed_archive_count }}</td>
               </tr>
             </tbody>
@@ -108,7 +110,7 @@
       <br />
       <hr class="hr" />
       <h1>Sequence Runs and Analyzes</h1>
-      <div v-if="analysis_ws || analysis_pa">
+      <div v-if="analysis_ws || analysis_pd">
         <h2>
           Waiting for fastq-files
           <button
@@ -124,7 +126,7 @@
         </h2>
         <div class="collapse show" id="waitintforfastq">
           <div class="card card-body">
-            <AnalysisTable analysis_status="WS,PA" />
+            <AnalysisTable analysis_status="WS,PD" />
           </div>
         </div>
       </div>
@@ -156,7 +158,15 @@
         </div>
       </div>
 
-      <div v-if="not_archived_count || analysis_ws || analysis_wp">
+      <div
+        v-if="
+          not_archived_count ||
+          analysis_ws ||
+          analysis_wp ||
+          analysis_sc ||
+          analysis_pd
+        "
+      >
         <h2>
           Not handled
           <button
@@ -181,17 +191,23 @@
             />
             <h4 v-if="not_archived_count">Not archived</h4>
             <SequenceRunTable archive_status="NA" v-if="not_archived_count" />
-            <h4 v-if="analysis_wp || analysis_ws">Analyzes</h4>
+            <h4 v-if="analysis_wp || analysis_ws || analysis_sc || analysis_pd">
+              Analyzes
+            </h4>
             <AnalysisTable
-              v-if="analysis_wp || analysis_ws"
+              v-if="analysis_wp || analysis_ws || analysis_sc || analysis_pd"
               title="Analysis"
-              analysis_status="WS,WP"
+              analysis_status="WS,SC,WP,PD"
             />
           </div>
         </div>
       </div>
 
-      <div v-if="analysis_re || analysis_pr || analysis_ad || archiving_count">
+      <div
+        v-if="
+          analysis_re || analysis_pr || analysis_ac || partially_archived_count
+        "
+      >
         <h2>
           Process running
           <button
@@ -207,13 +223,13 @@
         </h2>
         <div class="collapse show" id="processing">
           <div class="card card-body">
-            <div v-if="analysis_re || analysis_pr || analysis_ad">
+            <div v-if="analysis_re || analysis_pr || analysis_ac">
               <h4>Analyzes</h4>
-              <AnalysisTable analysis_status="RE,PR,AD" />
+              <AnalysisTable analysis_status="RE,PR,AC" />
             </div>
-            <div v-if="archiving_count">
+            <div v-if="partially_archived_count">
               <h4>Archiving</h4>
-              <SequenceRunTable archive_status="BA" />
+              <SequenceRunTable archive_status="PA" />
             </div>
           </div>
         </div>
@@ -258,18 +274,19 @@ export default {
       analysis: [],
       archive: [],
       analysis_ws: 0,
+      analysis_sc: 0,
       analysis_wp: 0,
       analysis_re: 0,
-      analysis_pa: 0,
+      analysis_pd: 0,
       analysis_pr: 0,
-      analysis_ad: 0,
+      analysis_ac: 0,
       analysis_dd: 0,
       analysis_fa: 0,
       assigned_analysis_as: 0,
       assigned_analysis_pa: 0,
       assigned_analysis_na: 0,
       archived_count: 0,
-      archiving_count: 0,
+      partially_archived_count: 0,
       failed_archive_count: 0,
       not_archived_count: 0,
       analysis_delivered: [],
@@ -284,21 +301,19 @@ export default {
         .get("api/v1/statistics/counts/")
         .then((response) => {
           //console.log(response.data);
-          this.sequence_runs = response.data.sequence_runs;
-          this.analysis = response.data.analysis;
-          this.archive = response.data.archive;
           this.archived_count = response.data.archive_count.AD;
-          this.archiving_count = response.data.archive_count.BA;
+          this.partially_archived_count = response.data.archive_count.PA;
           this.failed_archive_count = response.data.archive_count.FA;
           this.not_archived_count = response.data.archive_count.NA;
-          this.analysis_pa = response.data.analysis_count.PA;
           this.analysis_ws = response.data.analysis_count.WS;
+          this.analysis_sc = response.data.analysis_count.SC;
           this.analysis_wp = response.data.analysis_count.WP;
           this.analysis_re = response.data.analysis_count.RE;
           this.analysis_pr = response.data.analysis_count.PR;
-          this.analysis_ad = response.data.analysis_count.AD;
+          this.analysis_ac = response.data.analysis_count.AC;
           this.analysis_dd = response.data.analysis_count.DD;
           this.analysis_fa = response.data.analysis_count.FA;
+          this.analysis_pd = response.data.analysis_count.PD;
           this.assigned_analysis_as = response.data.assigned_analysis_count.AS;
           this.assigned_analysis_pa = response.data.assigned_analysis_count.PA;
           this.assigned_analysis_na = response.data.assigned_analysis_count.NA;


### PR DESCRIPTION
- Add SC (Sequencing Completed) and PD (Partial Demultiplexed) analysis statuses
- Replace use_for_archive_settings with archive_status using new archive status codes
- Replace BA (Being Archived) with PA (Partially Archived) across archive status maps
- Fix analysis_count keys: AD->AC, PA->PD; archive_count: BA→PA
- Update SequenceFilesTable empty-check from == 0 to .length === 0
- Fix AnalysisSampleTable to use nested sequence_run.run_id instead of flat ID
- Add NE samplesheet status and expand archive_status_name lookup in SequenceRunItem
- Fix typo "Deliverd" → "Delivered" in dashboard header
- Remove stale console.log calls

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
